### PR TITLE
Apply user's DRY_RUN to deleteNetworkInterfaceParams.

### DIFF
--- a/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
+++ b/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
@@ -2,7 +2,8 @@
 // This is useful for situations where you might have leftover ENIs that are not used and are preventing load balancer scaling
 'use strict';
 var AWS = require('aws-sdk');
-const dryRun = process.env.DRY_RUN || 'true';
+const dryRun = (process.env.DRY_RUN == 'true') || true;
+console.log('dryRun evaluated to %s, originally from %s.}', dryRun, process.env.DRY_RUN); //DEBUG
 
 //main function which gets AWS Health data from Cloudwatch event
 exports.handler = (event, context, callback) => {
@@ -31,13 +32,8 @@ exports.handler = (event, context, callback) => {
             for ( var i=0; i < data.NetworkInterfaces.length; i+=1)
             {
                 var netId = data.NetworkInterfaces[i].NetworkInterfaceId;
-                if (dryRun == 'true')
-                {
-                    console.log('Dry run is true - not deleting %s', netId);            
-                } else {
-                    console.log('No dry run - deleting %s', netId);
-                    deleteNetworkInterface(netId); 
-                }
+                console.log('Attempting to delete %s', netId);
+                deleteNetworkInterface(netId);
             }
         }
     });
@@ -52,7 +48,7 @@ function deleteNetworkInterface (networkInterfaceId) {
     console.log ('Attempting to delete the following ENI: %s', networkInterfaceId);
     var deleteNetworkInterfaceParams = {
         NetworkInterfaceId: networkInterfaceId,
-        DryRun: false
+        DryRun: dryRun
     };
     ec2.deleteNetworkInterface(deleteNetworkInterfaceParams, function(err, data) {
         if (err) console.log(networkInterfaceId, err, err.stack); // an error occurred

--- a/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
+++ b/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
@@ -3,8 +3,8 @@
 'use strict';
 var AWS = require('aws-sdk');
 
-// Only evaluates to false if the user enters false - missing or mistyped DRY_RUN results in a dry run.
-const dryRun = (process.env.DRY_RUN == '' || process.env.DRY_RUN != 'false');
+// Protect against missing or mistyped DRY_RUN variable.
+const dryRun = (process.env.DRY_RUN != 'false');
 
 //main function which gets AWS Health data from Cloudwatch event
 exports.handler = (event, context, callback) => {

--- a/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
+++ b/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
@@ -2,7 +2,7 @@
 // This is useful for situations where you might have leftover ENIs that are not used and are preventing load balancer scaling
 'use strict';
 var AWS = require('aws-sdk');
-const dryRun = (process.env.DRY_RUN == 'true') || true;
+const dryRun = (process.env.DRY_RUN == 'true');
 console.log('dryRun evaluated to %s, originally from %s.}', dryRun, process.env.DRY_RUN); //DEBUG
 
 //main function which gets AWS Health data from Cloudwatch event
@@ -32,7 +32,11 @@ exports.handler = (event, context, callback) => {
             for ( var i=0; i < data.NetworkInterfaces.length; i+=1)
             {
                 var netId = data.NetworkInterfaces[i].NetworkInterfaceId;
-                console.log('Attempting to delete %s', netId);
+                if (dryRun) {
+                    console.log('Dry run - not going to delete %s', netId);
+                } else {
+                    console.log('Not a dry run - deleting %s', netId);
+                }
                 deleteNetworkInterface(netId);
             }
         }

--- a/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
+++ b/automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/LambdaFunction.js
@@ -2,8 +2,9 @@
 // This is useful for situations where you might have leftover ENIs that are not used and are preventing load balancer scaling
 'use strict';
 var AWS = require('aws-sdk');
-const dryRun = (process.env.DRY_RUN == 'true');
-console.log('dryRun evaluated to %s, originally from %s.}', dryRun, process.env.DRY_RUN); //DEBUG
+
+// Only evaluates to false if the user enters false - missing or mistyped DRY_RUN results in a dry run.
+const dryRun = (process.env.DRY_RUN == '' || process.env.DRY_RUN != 'false');
 
 //main function which gets AWS Health data from Cloudwatch event
 exports.handler = (event, context, callback) => {


### PR DESCRIPTION
As discussed, here's a quick implementation of what I had in mind as far as having the EC2 client request a dry run of the ENI deletion, allowing full code coverage testing. Nothing too involved, passed testing of a missing, blank or mistyped DRY_RUN variable. Started going a more complicated route, then found a much simpler approach.